### PR TITLE
[BUGFIX] Request required permission for scheduled workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,8 @@ jobs:
           - 12
         command:
           - "cgl -n"
-          - "composerNormalize -n"
+          # @todo Disabled due to https://github.com/ergebnis/composer-normalize/issues/1287
+          # - "composerNormalize -n"
           # - "composerNamespaceVerify"
           - "phpstan"
     steps:

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -8,6 +8,7 @@ jobs:
   main:
     name: "kick-off nightlies"
     runs-on: ubuntu-22.04
+    permissions: write-all
     strategy:
       matrix:
         workflowName:


### PR DESCRIPTION
The introduced scheduled job dispatcher failes
due to insufficient permissions. To mitigate,
a proper permission request needs to be added.

This change modifes the `scheduled.yml` GitHub
action workflow to request required permissions.

Note: composer normalizer is disabled temporarly
due to a unwanted behaviour. Todo comment for
disabled workflow action is added. [1]

[1] https://github.com/ergebnis/composer-normalize/issues/1287

Resolves: #2
Releases: main
