### PR TITLE
[TASK] Remove dev dependency `"ergebnis/composer-normalize"`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,8 +49,6 @@ jobs:
           - 12
         command:
           - "cgl -n"
-          # @todo Disabled due to https://github.com/ergebnis/composer-normalize/issues/1287
-          # - "composerNormalize -n"
           # - "composerNamespaceVerify"
           - "phpstan"
     steps:

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -235,7 +235,7 @@ Options:
         replay the unit tests in that order.
 
     -n
-        Only with -s cgl|composerNormalize
+        Only with -s cgl
         Activate dry-run in CGL check that does not actively change files and only prints broken ones.
 
     -u
@@ -494,7 +494,7 @@ case ${TEST_SUITE} in
         ;;
     composer)
         COMMAND=(composer "$@")
-        ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name composer-command-${SUFFIX} -e COMPOSER_CACHE_DIR=.Build/.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} /bin/sh -c "${COMMAND[@]}"
+        ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name composer-command-${SUFFIX} -e COMPOSER_CACHE_DIR=.Build/.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} "${COMMAND[@]}"
         SUITE_EXIT_CODE=$?
         ;;
     composerInstall)
@@ -549,16 +549,6 @@ case ${TEST_SUITE} in
         SUITE_EXIT_CODE=$?
         cp ${ROOT_DIR}/composer.json ${ROOT_DIR}/composer.json.testing
         mv ${ROOT_DIR}/composer.json.orig ${ROOT_DIR}/composer.json
-        ;;
-    composerNormalize)
-        COMMAND="composer ci:composer:normalize"
-        if [ "${CGLCHECK_DRY_RUN}" -eq 1 ]; then
-            COMMAND="composer composer:normalize:check"
-        else
-            COMMAND="composer composer:normalize:fix"
-        fi
-        ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name composer-normalize-${SUFFIX} -e COMPOSER_CACHE_DIR=.Build/.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} ${COMMAND}
-        SUITE_EXIT_CODE=$?
         ;;
     functional)
         COMMAND=(.Build/bin/phpunit -c Build/phpunit/FunctionalTests-${CORE_VERSION}.xml --exclude-group not-${DBMS} "$@")

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,6 @@
     },
     "require-dev": {
         "bnf/phpstan-psr-container": "^1.0",
-        "ergebnis/composer-normalize": "^2.42.0",
         "friendsofphp/php-cs-fixer": "^3.16.0",
         "friendsoftypo3/phpstan-typo3": "^0.9.0",
         "phpspec/prophecy": "^1.15.0",
@@ -44,7 +43,6 @@
     },
     "config": {
         "allow-plugins": {
-            "ergebnis/composer-normalize": true,
             "typo3/class-alias-loader": true,
             "typo3/cms-composer-installers": true
         },


### PR DESCRIPTION
The hyped `"ergebnis/composer-normalize"` composer plugin to
normalize composer.json file and using it as a pipeline check
operats strictly on semver and not allowing a more practical
approach regardin the version handling of dependencies. 

Due to the fact that having another mindset then this plugin,
it's not usable until it can be controlled. [1]

Therefore, the plugin is removed again until this point which
may never come. Handling the composer.json file manually in
shape is doable.

Used command(s):

```terminal
> Build/Scripts/runTests.sh -s composer \
    -- remove --dev "ergebnis/composer-normalize"
```

[1] https://github.com/ergebnis/composer-normalize/issues/1287

Releases: main